### PR TITLE
fix: broadcast text guidance across hand batches

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -58,7 +58,7 @@ def main(cfg):
 
     if cfg.eval.text_guidance_scale != -1.0:
         print(f"### Setting the text guidance scale to {cfg.eval.text_guidance_scale} for evaluation")
-        text_scale = th.ones(cfg.eval.batch_size, device=dist_util.dev()) * cfg.eval.text_guidance_scale
+        text_scale = th.tensor(cfg.eval.text_guidance_scale, device=dist_util.dev())
         _model = ClassifierFreeSampleModel(_model, text_scale=text_scale)
         output_path = output_path + f"_textscale{cfg.eval.text_guidance_scale}"
     


### PR DESCRIPTION
## Summary

Fix classifier-free text guidance for hand-stream sampling when the effective
batch size differs from `eval.batch_size`.

## Problem

The text-guidance scale was created as a tensor with `eval.batch_size`
elements. Hand preprocessing splits each sample into left and right hands,
doubling the effective model batch from `B` to `2B`.

### Reproduction

```bash
python sample.py \
  data_v2=hand \
  data_v2/common@common=inference \
  eval.model_path=/path/to/hand/checkpoint.pt \
  flip_left_hand=True \
  eval.split=test \
  'test_data=[CSL-Daily]' \
  eval.text_guidance_scale=2.0 \
  eval.batch_size=64 \
  eval.max_samples=64 \
  eval.ode_stepnum=20 \
  eval.candidate_num=1
```

the command failed with:
```bash
RuntimeError: The size of tensor a (64) must match the size of tensor b (128)
at non-singleton dimension 0
```
The configured batch size was 64, while hand preprocessing produced an
effective model batch size of 128.

## Fix
Create the uniform guidance scale as a scalar tensor. It then broadcasts across
the actual model batch size while preserving the configured guidance value.

## Validation
- Verified guidance broadcasting with an effective hand batch shape of
(128, 90, 304).
- Reproduced with eval.batch_size=64 and
eval.text_guidance_scale=2.0.